### PR TITLE
Docker base image to miniconda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,13 @@
-FROM mcs07/rdkit:latest
+FROM continuumio/miniconda3:latest
 
 MAINTAINER Mingxun Wang "mwang87@gmail.com"
 
+WORKDIR /app
+COPY requirements.txt /app
 RUN apt-get update -y
-RUN apt-get install -y python3-pip python3-dev build-essential
-RUN apt-get install -y default-jre
+RUN conda create -n rdkit -c rdkit rdkit
+RUN apt-get install -y libxrender-dev
 
-RUN pip3 install flask
-RUN pip3 install gunicorn
-RUN pip3 install Pillow
-RUN pip3 install requests
-RUN pip3 install matplotlib
-RUN pip3 install cairocffi
+RUN /bin/bash -c "source activate rdkit && pip install -r requirements.txt"
 
 COPY . /app
-WORKDIR /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+gunicorn
+requests

--- a/run_dev_server.sh
+++ b/run_dev_server.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-
-python3 ./main.py
+source activate rdkit
+python ./main.py

--- a/run_server.sh
+++ b/run_server.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-
+source activate rdkit
 gunicorn -w 4 --bind 0.0.0.0:5000 app:app


### PR DESCRIPTION
### Migrate Docker image to miniconda3.

Made appropriate changes to install RDKit and run app with conda python.
1) Update Dockerfile
2) Move python dependencies to `requirements.txt`
3) Update bash scripts to use conda python